### PR TITLE
fix: hacky update `mappedState`

### DIFF
--- a/src/useCustomSelector.lua
+++ b/src/useCustomSelector.lua
@@ -10,8 +10,9 @@ local function useCustomSelector(
 )
 	local store = hooks.useContext(context)
 	local mappedState, setMappedState = hooks.useState(function()
-		return { selector(store:getState()) }
+		return selector(store:getState())
 	end)
+	local oldMappedState = hooks.useValue(mappedState)
 
 	if equalityFn == nil then
 		equalityFn = defaultEqualityFn
@@ -21,9 +22,9 @@ local function useCustomSelector(
 		local storeChanged = store.changed:connect(function(newState, _oldState)
 			local newMappedState = selector(newState)
 
-			if not equalityFn(newMappedState, mappedState[1]) then
-				mappedState[1] = newMappedState
-				setMappedState(mappedState)
+			if not equalityFn(newMappedState, oldMappedState.value) then
+				oldMappedState.value = newMappedState
+				setMappedState(newMappedState)
 			end
 		end)
 
@@ -32,7 +33,7 @@ local function useCustomSelector(
 		end
 	end, {})
 
-	return mappedState[1]
+	return mappedState
 end
 
 return useCustomSelector

--- a/src/useCustomSelector.lua
+++ b/src/useCustomSelector.lua
@@ -10,7 +10,7 @@ local function useCustomSelector(
 )
 	local store = hooks.useContext(context)
 	local mappedState, setMappedState = hooks.useState(function()
-		return selector(store:getState())
+		return { selector(store:getState()) }
 	end)
 
 	if equalityFn == nil then
@@ -21,8 +21,9 @@ local function useCustomSelector(
 		local storeChanged = store.changed:connect(function(newState, _oldState)
 			local newMappedState = selector(newState)
 
-			if not equalityFn(newMappedState, mappedState) then
-				setMappedState(newMappedState)
+			if not equalityFn(newMappedState, mappedState[1]) then
+				mappedState[1] = newMappedState
+				setMappedState(mappedState)
 			end
 		end)
 
@@ -31,7 +32,7 @@ local function useCustomSelector(
 		end
 	end, {})
 
-	return mappedState
+	return mappedState[1]
 end
 
 return useCustomSelector


### PR DESCRIPTION
I had an issue and then were debugging by myself
```lua
local mappedState, setMappedState = ...

useEffect(function()
    print(mappedState)
end, {})
```
mappedState does not get updated because of the second param `{}`(if I remove the second param, it works as expected), the function is only executed once(on mount), so the `mappedState` variable will not get updated, I made a "hacky" solution using "pointers" concept.

The issue itself can be reached with this:
```lua
local lives = RoduxHooks.useSelector(function(state)
    return state.lives
end)

print(lives)

...
Button1 = e("TextButton", {
    ...
    [Roact.Event.Activated] = function()
        dispatch(DecrementLives()) -- [3 -> 2] [2 -> 1] [1 -> 0]
        -- the initial value is 3, so `mappedState` has 3 as initial value too,
        -- note that on every dispatch, `mappedState` inside `useEffect`'s function always is 3
    end,
},
Button2 = e("TextButton", {
    ...
    [Roact.Event.Activated] = function()
        dispatch(ResetLives()) --> 3
        -- when the initial value was decremented and this executed,
        -- `3` will not print because it's comparing the new value(3)
        -- with the initial value(3, because as I said, it was not updated)
    end,
},
...
