### PR TITLE
Fix selectors not properly updating selector function enclosures

### DIFF
--- a/src/useCustomSelector.lua
+++ b/src/useCustomSelector.lua
@@ -13,7 +13,9 @@ local function useCustomSelector(
 	selectorFunc.value = selector
 
 	local store = hooks.useContext(context)
-	local mappedState, setMappedState = hooks.useState(selector(store:getState()))
+	local mappedState, setMappedState = hooks.useState(function()
+		return selector(store:getState())
+	end)
 	local oldMappedState = hooks.useValue(mappedState)
 
 	if equalityFn == nil then

--- a/src/useCustomSelector.lua
+++ b/src/useCustomSelector.lua
@@ -4,14 +4,16 @@ end
 
 local function useCustomSelector(
 	hooks,
-	selector: (state: table) -> any,
-	equalityFn: ((newState: table, oldState: table) -> boolean)?,
+	selector: (state: any) -> any,
+	equalityFn: ((newState: any, oldState: any) -> boolean)?,
 	context
 )
+	-- This value wrapper is required so the variable context of the selector function can be updated on each run --
+	local selectorFunc = hooks.useValue()
+	selectorFunc.value = selector
+
 	local store = hooks.useContext(context)
-	local mappedState, setMappedState = hooks.useState(function()
-		return selector(store:getState())
-	end)
+	local mappedState, setMappedState = hooks.useState(selector(store:getState()))
 	local oldMappedState = hooks.useValue(mappedState)
 
 	if equalityFn == nil then
@@ -20,7 +22,7 @@ local function useCustomSelector(
 
 	hooks.useEffect(function()
 		local storeChanged = store.changed:connect(function(newState, _oldState)
-			local newMappedState = selector(newState)
+			local newMappedState = selectorFunc.value(newState)
 
 			if not equalityFn(newMappedState, oldMappedState.value) then
 				oldMappedState.value = newMappedState


### PR DESCRIPTION
The `useCustomSelector` hook (and by proxy `useSelector`) doesn't properly update selector function enclosures on each call. This means that if one of the external variables your selector function uses changes, the selector won't actually receive the updated version until it remounts the component.
I just tested this fix by locally modifying the Wally package on our team's project and it seems to work like a charm.